### PR TITLE
Add indexer helper module

### DIFF
--- a/lib/indexer.py
+++ b/lib/indexer.py
@@ -1,0 +1,34 @@
+"""Utility helpers for loading and querying the character index.
+
+The preprocessing script ``scripts/preprocess.py`` generates an inverted
+character index in JSON format. The index is stored as ``char_index.json``
+inside the chosen output directory. This module provides two small helper
+functions to work with that file::
+
+    from lib.indexer import load_index, query_char
+
+    index = load_index('./index')
+    hits = query_char('李', index)
+
+Each element returned from ``query_char`` is a dictionary describing one
+occurrence of the character. The structure matches what is written by the
+preprocessing script (``work_id``, ``type``, ``paragraph`` etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Any
+
+
+def load_index(index_dir: str) -> Dict[str, List[Dict[str, Any]]]:
+    """Load ``char_index.json`` from ``index_dir`` and return the data."""
+    index_path = os.path.join(index_dir, 'char_index.json')
+    with open(index_path, 'r', encoding='utf-8') as fh:
+        return json.load(fh)
+
+
+def query_char(char: str, index: Dict[str, List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    """Return the list of occurrences for ``char`` from the loaded index."""
+    return index.get(char, [])

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,26 @@
+import json
+import os
+from lib.indexer import load_index, query_char
+
+
+def test_load_and_query(tmp_path):
+    index_data = {
+        '李': [
+            {'work_id': 'w1', 'type': 'poetry', 'paragraph': 1, 'line': 1, 'pos': 1, 'tone': 3}
+        ],
+        '白': [
+            {'work_id': 'w2', 'type': 'poetry', 'paragraph': 2, 'line': 3, 'pos': 2, 'tone': 2}
+        ],
+    }
+    index_path = tmp_path / 'char_index.json'
+    with open(index_path, 'w', encoding='utf-8') as fh:
+        json.dump(index_data, fh, ensure_ascii=False)
+
+    index = load_index(tmp_path)
+    assert index == index_data
+
+    li_hits = query_char('李', index)
+    assert li_hits == index_data['李']
+
+    unknown_hits = query_char('王', index)
+    assert unknown_hits == []


### PR DESCRIPTION
## Summary
- add `lib/indexer.py` with helpers to load and query the character index
- test `load_index` and `query_char`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb6abac9c832c90674e69b4855922