### PR TITLE
Fix tone digit parsing in preprocess

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -79,7 +79,14 @@ def main(data_dir: str, index_dir: str) -> None:
                             None,
                         )
                         if digit:
-                            tone_digit = int(digit)
+                            try:
+                                tone_digit = int(digit)
+                            except ValueError:
+                                import unicodedata
+                                try:
+                                    tone_digit = int(unicodedata.digit(digit))
+                                except Exception:
+                                    tone_digit = 0
 
                     char_index[ch].append(
                         {


### PR DESCRIPTION
## Summary
- handle unicode tone digits in `preprocess.py`

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685feda0ba70832cb666492651927315